### PR TITLE
fix: cover SECURITY DEFINER, auth.role() deprecation, and BOLA in security checklist

### DIFF
--- a/skills/supabase-postgres-best-practices/references/security-rls-performance.md
+++ b/skills/supabase-postgres-best-practices/references/security-rls-performance.md
@@ -29,9 +29,11 @@ create policy orders_policy on orders
 
 Use security definer functions for complex checks:
 
+`SECURITY DEFINER` functions run with the creator's privileges and bypass RLS on any tables they touch — which is what makes them useful for internal lookups, but also what makes them dangerous if misused. Always include an explicit `auth.uid()` check inside the function body, keep them in a non-exposed schema, and revoke `EXECUTE` from any role that shouldn't call them directly.
+
 ```sql
--- Create helper function (runs as definer, bypasses RLS)
-create or replace function is_team_member(team_id bigint)
+-- Create helper function in a private schema
+create or replace function private.is_team_member(team_id bigint)
 returns boolean
 language sql
 security definer
@@ -39,13 +41,17 @@ set search_path = ''
 as $$
   select exists (
     select 1 from public.team_members
+    -- always check the calling user's identity inside the function
     where team_id = $1 and user_id = (select auth.uid())
   );
 $$;
 
+-- Revoke direct execution from public roles
+revoke execute on function private.is_team_member(bigint) from anon, authenticated, public;
+
 -- Use in policy (indexed lookup, not per-row check)
 create policy team_orders_policy on orders
-  using ((select is_team_member(team_id)));
+  using ((select private.is_team_member(team_id)));
 ```
 
 Always add indexes on columns used in RLS policies:

--- a/skills/supabase-postgres-best-practices/references/security-rls-performance.md
+++ b/skills/supabase-postgres-best-practices/references/security-rls-performance.md
@@ -47,7 +47,7 @@ as $$
 $$;
 
 -- Revoke direct execution from public roles
-revoke execute on function private.is_team_member(bigint) from anon, authenticated, public;
+revoke execute on function private.is_team_member(bigint) from PUBLIC, anon, authenticated, service_role;
 
 -- Use in policy (indexed lookup, not per-row check)
 create policy team_orders_policy on orders

--- a/skills/supabase/SKILL.md
+++ b/skills/supabase/SKILL.md
@@ -64,7 +64,7 @@ When working on any Supabase task that touches auth, RLS, views, storage, or use
     with check ( (select auth.uid()) = user_id );
     ```
   - **`SECURITY DEFINER` functions bypass RLS.** A `SECURITY DEFINER` function runs with its creator's privileges — typically a role with `bypassrls` (e.g., `postgres`). Never add `SECURITY DEFINER` to resolve a permission error; it silently removes access control without fixing the underlying cause. Prefer `SECURITY INVOKER`.
-  - **`SECURITY DEFINER` functions in `public` are callable by all roles.** Postgres grants `EXECUTE` to all roles by default for every new function, so any `SECURITY DEFINER` function in `public` is a public API endpoint callable by `anon` and `authenticated` without any explicit grant. When `SECURITY DEFINER` is genuinely needed (e.g., bypassing RLS on an internal lookup table), keep the function in a non-exposed schema, always include an `auth.uid()` check in the function body, and run `supabase db advisors` after making changes.
+  - **`SECURITY DEFINER` functions in `public` are callable by all roles.** Postgres grants `EXECUTE` to `PUBLIC` by default for every new function, so any `SECURITY DEFINER` function in `public` is a public API endpoint callable by `anon` and `authenticated` (which inherit from `PUBLIC`) without any additional grant. When `SECURITY DEFINER` is genuinely needed (e.g., bypassing RLS on an internal lookup table), keep the function in a non-exposed schema, always include an `auth.uid()` check in the function body, and run `supabase db advisors` after making changes.
 
 - **Storage access control**
   - **Storage upsert requires INSERT + SELECT + UPDATE.** Granting only INSERT allows new uploads but file replacement (upsert) silently fails. You need all three.

--- a/skills/supabase/SKILL.md
+++ b/skills/supabase/SKILL.md
@@ -3,7 +3,7 @@ name: supabase
 description: "Use when doing ANY task involving Supabase. Triggers: Supabase products (Database, Auth, Edge Functions, Realtime, Storage, Vectors, Cron, Queues); client libraries and SSR integrations (supabase-js, @supabase/ssr) in Next.js, React, SvelteKit, Astro, Remix; auth issues (login, logout, sessions, JWT, cookies, getSession, getUser, getClaims, RLS); Supabase CLI or MCP server; schema changes, migrations, security audits, Postgres extensions (pg_graphql, pg_cron, pg_vector)."
 metadata:
   author: supabase
-  version: "0.1.3"
+  version: "0.1.2"
 ---
 
 # Supabase
@@ -44,25 +44,27 @@ When working on any Supabase task that touches auth, RLS, views, storage, or use
 - **RLS, views, and privileged database code**
   - **Views bypass RLS by default.** In Postgres 15 and above, use `CREATE VIEW ... WITH (security_invoker = true)`. In older versions of Postgres, protect your views by revoking access from the `anon` and `authenticated` roles, or by putting them in an unexposed schema.
   - **UPDATE requires a SELECT policy.** In Postgres RLS, an UPDATE needs to first SELECT the row. Without a SELECT policy, updates silently return 0 rows — no error, just no change.
-  - **`auth.role()` is deprecated — use the `TO` clause instead.** Supabase has deprecated `auth.role()` in favour of specifying the target role directly on the policy with `TO authenticated` or `TO anon`. Beyond deprecation, `auth.role() = 'authenticated'` breaks silently when anonymous sign-ins are enabled, because anonymous users carry the `authenticated` Postgres role and pass the check regardless of whether the user is genuinely signed in. Using `TO authenticated` only checks the role — it does not restrict which rows a user can access. The correct pattern combines `TO authenticated` with an ownership predicate in `USING`. For UPDATE, both `USING` and `WITH CHECK` are required — without `WITH CHECK` a user can reassign a row's `user_id` to another user:
+  - **`auth.role()` is deprecated — use the `TO` clause instead.** Supabase has deprecated `auth.role()` in favour of specifying the target role directly on the policy with `TO authenticated` or `TO anon`. Beyond deprecation, `auth.role() = 'authenticated'` breaks silently when anonymous sign-ins are enabled, because anonymous users carry the `authenticated` Postgres role and pass the check regardless of whether the user is genuinely signed in.
     ```sql
     -- Deprecated (do not use)
     create policy "example" on table_name for select
     using ( auth.role() = 'authenticated' );
-
-    -- Correct
-    -- Select
+    ```
+  - **`TO authenticated` alone is authentication without authorization (BOLA / IDOR).** Using `TO authenticated` only checks the role — it does not restrict which rows a user can access. The correct pattern combines `TO authenticated` with an ownership predicate in `USING`:
+    ```sql
     create policy "example" on table_name for select
     to authenticated
     using ( (select auth.uid()) = user_id );
-
-    -- Update (note the WITH CHECK)
+    ```
+  - **UPDATE policies require both `USING` and `WITH CHECK`.** Without `WITH CHECK`, a user can reassign a row's `user_id` to another user:
+    ```sql
     create policy "example" on table_name for update
     to authenticated
     using ( (select auth.uid()) = user_id )
     with check ( (select auth.uid()) = user_id );
     ```
-  - **`SECURITY DEFINER` functions bypass RLS and are callable by all roles by default.** A `SECURITY DEFINER` function runs with its creator's privileges — typically a superuser with `bypassrls`. Supabase also grants `EXECUTE` to `anon`, `authenticated`, and `service_role` for all new functions in `public` by default, making any such function a public API endpoint until that grant is explicitly revoked. Never add `SECURITY DEFINER` to resolve a permission error; it silently removes access control without fixing the underlying cause. Prefer `SECURITY INVOKER`. When `SECURITY DEFINER` is genuinely needed (e.g., bypassing RLS on an internal lookup table), keep the function in a non-exposed schema and always include an `auth.uid()` check in the function body. After any changes involving functions, run `supabase db advisors` and address any findings.
+  - **`SECURITY DEFINER` functions bypass RLS.** A `SECURITY DEFINER` function runs with its creator's privileges — typically a role with `bypassrls` (e.g., `postgres`). Never add `SECURITY DEFINER` to resolve a permission error; it silently removes access control without fixing the underlying cause. Prefer `SECURITY INVOKER`.
+  - **`SECURITY DEFINER` functions in `public` are callable by all roles.** Postgres grants `EXECUTE` to all roles by default for every new function, so any `SECURITY DEFINER` function in `public` is a public API endpoint callable by `anon` and `authenticated` without any explicit grant. When `SECURITY DEFINER` is genuinely needed (e.g., bypassing RLS on an internal lookup table), keep the function in a non-exposed schema, always include an `auth.uid()` check in the function body, and run `supabase db advisors` after making changes.
 
 - **Storage access control**
   - **Storage upsert requires INSERT + SELECT + UPDATE.** Granting only INSERT allows new uploads but file replacement (upsert) silently fails. You need all three.

--- a/skills/supabase/SKILL.md
+++ b/skills/supabase/SKILL.md
@@ -3,7 +3,7 @@ name: supabase
 description: "Use when doing ANY task involving Supabase. Triggers: Supabase products (Database, Auth, Edge Functions, Realtime, Storage, Vectors, Cron, Queues); client libraries and SSR integrations (supabase-js, @supabase/ssr) in Next.js, React, SvelteKit, Astro, Remix; auth issues (login, logout, sessions, JWT, cookies, getSession, getUser, getClaims, RLS); Supabase CLI or MCP server; schema changes, migrations, security audits, Postgres extensions (pg_graphql, pg_cron, pg_vector)."
 metadata:
   author: supabase
-  version: "0.1.2"
+  version: "0.1.3"
 ---
 
 # Supabase
@@ -44,7 +44,7 @@ When working on any Supabase task that touches auth, RLS, views, storage, or use
 - **RLS, views, and privileged database code**
   - **Views bypass RLS by default.** In Postgres 15 and above, use `CREATE VIEW ... WITH (security_invoker = true)`. In older versions of Postgres, protect your views by revoking access from the `anon` and `authenticated` roles, or by putting them in an unexposed schema.
   - **UPDATE requires a SELECT policy.** In Postgres RLS, an UPDATE needs to first SELECT the row. Without a SELECT policy, updates silently return 0 rows — no error, just no change.
-  - **Do not put `security definer` functions in an exposed schema.** Keep them in a private or otherwise unexposed schema.
+  - **`SECURITY DEFINER` functions bypass RLS and are callable by all roles by default.** A `SECURITY DEFINER` function runs with its creator's privileges — typically a superuser with `bypassrls`. Supabase also grants `EXECUTE` to `anon`, `authenticated`, and `service_role` for all new functions in `public` by default, making any such function a public API endpoint until that grant is explicitly revoked. Never add `SECURITY DEFINER` to resolve a permission error; it silently removes access control without fixing the underlying cause. Prefer `SECURITY INVOKER`. When `SECURITY DEFINER` is genuinely needed (e.g., bypassing RLS on an internal lookup table), keep the function in a non-exposed schema and always include an `auth.uid()` check in the function body. After any changes involving functions, run `supabase db advisors` and address any findings.
 
 - **Storage access control**
   - **Storage upsert requires INSERT + SELECT + UPDATE.** Granting only INSERT allows new uploads but file replacement (upsert) silently fails. You need all three.

--- a/skills/supabase/SKILL.md
+++ b/skills/supabase/SKILL.md
@@ -44,16 +44,23 @@ When working on any Supabase task that touches auth, RLS, views, storage, or use
 - **RLS, views, and privileged database code**
   - **Views bypass RLS by default.** In Postgres 15 and above, use `CREATE VIEW ... WITH (security_invoker = true)`. In older versions of Postgres, protect your views by revoking access from the `anon` and `authenticated` roles, or by putting them in an unexposed schema.
   - **UPDATE requires a SELECT policy.** In Postgres RLS, an UPDATE needs to first SELECT the row. Without a SELECT policy, updates silently return 0 rows — no error, just no change.
-  - **`auth.role()` is deprecated — use the `TO` clause instead.** Supabase has deprecated `auth.role()` in favour of specifying the target role directly on the policy with `TO authenticated` or `TO anon`. Beyond deprecation, `auth.role() = 'authenticated'` breaks silently when anonymous sign-ins are enabled, because anonymous users carry the `authenticated` Postgres role and pass the check regardless of whether the user is genuinely signed in. The correct pattern is `TO authenticated` on the policy combined with `auth.uid()` checks in `USING`:
+  - **`auth.role()` is deprecated — use the `TO` clause instead.** Supabase has deprecated `auth.role()` in favour of specifying the target role directly on the policy with `TO authenticated` or `TO anon`. Beyond deprecation, `auth.role() = 'authenticated'` breaks silently when anonymous sign-ins are enabled, because anonymous users carry the `authenticated` Postgres role and pass the check regardless of whether the user is genuinely signed in. Using `TO authenticated` only checks the role — it does not restrict which rows a user can access. The correct pattern combines `TO authenticated` with an ownership predicate in `USING`. For UPDATE, both `USING` and `WITH CHECK` are required — without `WITH CHECK` a user can reassign a row's `user_id` to another user:
     ```sql
     -- Deprecated (do not use)
     create policy "example" on table_name for select
     using ( auth.role() = 'authenticated' );
 
     -- Correct
+    -- Select
     create policy "example" on table_name for select
     to authenticated
     using ( (select auth.uid()) = user_id );
+
+    -- Update (note the WITH CHECK)
+    create policy "example" on table_name for update
+    to authenticated
+    using ( (select auth.uid()) = user_id )
+    with check ( (select auth.uid()) = user_id );
     ```
   - **`SECURITY DEFINER` functions bypass RLS and are callable by all roles by default.** A `SECURITY DEFINER` function runs with its creator's privileges — typically a superuser with `bypassrls`. Supabase also grants `EXECUTE` to `anon`, `authenticated`, and `service_role` for all new functions in `public` by default, making any such function a public API endpoint until that grant is explicitly revoked. Never add `SECURITY DEFINER` to resolve a permission error; it silently removes access control without fixing the underlying cause. Prefer `SECURITY INVOKER`. When `SECURITY DEFINER` is genuinely needed (e.g., bypassing RLS on an internal lookup table), keep the function in a non-exposed schema and always include an `auth.uid()` check in the function body. After any changes involving functions, run `supabase db advisors` and address any findings.
 

--- a/skills/supabase/SKILL.md
+++ b/skills/supabase/SKILL.md
@@ -44,6 +44,17 @@ When working on any Supabase task that touches auth, RLS, views, storage, or use
 - **RLS, views, and privileged database code**
   - **Views bypass RLS by default.** In Postgres 15 and above, use `CREATE VIEW ... WITH (security_invoker = true)`. In older versions of Postgres, protect your views by revoking access from the `anon` and `authenticated` roles, or by putting them in an unexposed schema.
   - **UPDATE requires a SELECT policy.** In Postgres RLS, an UPDATE needs to first SELECT the row. Without a SELECT policy, updates silently return 0 rows — no error, just no change.
+  - **`auth.role()` is deprecated — use the `TO` clause instead.** Supabase has deprecated `auth.role()` in favour of specifying the target role directly on the policy with `TO authenticated` or `TO anon`. Beyond deprecation, `auth.role() = 'authenticated'` breaks silently when anonymous sign-ins are enabled, because anonymous users carry the `authenticated` Postgres role and pass the check regardless of whether the user is genuinely signed in. The correct pattern is `TO authenticated` on the policy combined with `auth.uid()` checks in `USING`:
+    ```sql
+    -- Deprecated (do not use)
+    create policy "example" on table_name for select
+    using ( auth.role() = 'authenticated' );
+
+    -- Correct
+    create policy "example" on table_name for select
+    to authenticated
+    using ( (select auth.uid()) = user_id );
+    ```
   - **`SECURITY DEFINER` functions bypass RLS and are callable by all roles by default.** A `SECURITY DEFINER` function runs with its creator's privileges — typically a superuser with `bypassrls`. Supabase also grants `EXECUTE` to `anon`, `authenticated`, and `service_role` for all new functions in `public` by default, making any such function a public API endpoint until that grant is explicitly revoked. Never add `SECURITY DEFINER` to resolve a permission error; it silently removes access control without fixing the underlying cause. Prefer `SECURITY INVOKER`. When `SECURITY DEFINER` is genuinely needed (e.g., bypassing RLS on an internal lookup table), keep the function in a non-exposed schema and always include an `auth.uid()` check in the function body. After any changes involving functions, run `supabase db advisors` and address any findings.
 
 - **Storage access control**


### PR DESCRIPTION
Four additions covering vulnerability patterns common in AI-generated Supabase apps.

- **[`SECURITY DEFINER`](https://supabase.com/docs/guides/database/postgres/row-level-security#use-security-definer-functions)** runs as its creator (typically a superuser with `bypassrls`), and Supabase grants `EXECUTE` to all roles by default for new `public` functions — making it a public API endpoint until revoked. Guidance from [lint 0028](https://supabase.com/docs/guides/database/database-advisors?queryGroups=lint&lint=0028_anon_security_definer_function_executable) and [lint 0029](https://supabase.com/docs/guides/database/database-advisors?queryGroups=lint&lint=0029_authenticated_security_definer_function_executable). Updated in both skills — `supabase` checklist and the `SECURITY DEFINER` example in `supabase-postgres-best-practices/security-rls-performance.md`, which previously showed the pattern without any safety constraints.

- **[`auth.role()`](https://supabase.com/docs/guides/troubleshooting/deprecated-rls-features-Pm77Zs)** is deprecated in favour of the `TO` clause, and silently grants access to [anonymous users](https://supabase.com/docs/guides/auth/auth-anonymous) (who carry the `authenticated` Postgres role) when anonymous sign-ins are enabled.

- **[BOLA](https://supabase.com/docs/guides/database/postgres/row-level-security)** — `TO authenticated USING (true)` checks the role, not ownership. Row ownership requires `auth.uid() = user_id` in `USING`, and UPDATE needs `WITH CHECK` too to prevent `user_id` reassignment.

Closes [AI-741](https://linear.app/supabase/issue/AI-741/cover-additional-security-cases-in-supabase-skill)