### PR TITLE
fix: scope supabase-plugin app token to the correct installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,8 @@ jobs:
         with:
           client-id: ${{ secrets.GH_APP_ID_SUPABASE_PLUGIN }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_SUPABASE_PLUGIN }}
+          owner: supabase-community
+          repositories: supabase-plugin
 
       - name: Trigger supabase-plugin skill sync
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Summary

- The second `create-github-app-token` step in `release.yml` was failing with `404 Not Found` on `GET /repos/supabase/agent-skills/installation`.
- Root cause: the `sb-community-agent-skills-releaser` GitHub App is installed on `supabase-community/supabase-plugin`, not on this repo. Without `owner` / `repositories` inputs, the action defaults to looking up the installation on `github.repository`, which doesn't exist for that App here.
- Fix: pass `owner: supabase-community` and `repositories: supabase-plugin` so the action queries the correct installation.

Failing run: https://github.com/supabase/agent-skills/actions/runs/26111932790/job/76791143314

## Validation

Verified end-to-end on a throwaway branch by minting a token with the same App + new inputs, then:

- Reading `supabase-community/supabase-plugin` metadata via `gh api`
- Pushing a branch and opening a PR on `supabase-community/supabase-plugin` — ([PR closed](https://github.com/supabase-community/supabase-plugin/pull/20), branch deleted)