### PR TITLE
feat: add npm supply-chain security guidance to supabase skill

### DIFF
--- a/skills/supabase/SKILL.md
+++ b/skills/supabase/SKILL.md
@@ -69,6 +69,9 @@ When working on any Supabase task that touches auth, RLS, views, storage, or use
 - **Storage access control**
   - **Storage upsert requires INSERT + SELECT + UPDATE.** Granting only INSERT allows new uploads but file replacement (upsert) silently fails. You need all three.
 
+- **Dependency and supply-chain security**
+  - **Always pin package versions and commit lockfiles** when installing Supabase packages (`supabase-js`, `@supabase/ssr`, `supabase-py`, etc.). See the [npm security guide](https://supabase.com/docs/guides/security/npm-security.md) for the full checklist.
+
 For any security concern not covered above, fetch the Supabase product security index: `https://supabase.com/docs/guides/security/product-security.md`
 
 ## Supabase CLI


### PR DESCRIPTION
## Summary

Adds a **Dependency and supply-chain security** sub-section to the Supabase skill's security checklist, with a link to the [npm security guide](https://supabase.com/docs/guides/security/npm-security)

## Test plan

Manually tested with Claude Sonnet 4.6 in Claude Code. The model loaded the Supabase skill and pinned the versions of `@supabase/ssr` and `@supabase/supabase-js`.

<img width="576" height="123" alt="image" src="https://github.com/user-attachments/assets/c0572673-e3ea-4f8e-8482-f005be76acab" />

Closes AI-785