### PR TITLE
chore: remove undefined inputs from supabase-plugin sync workflow trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,4 @@ jobs:
         run: |
           gh workflow run sync-agent-skills.yml \
             --repo supabase-community/supabase-plugin \
-            --field release_tag=${{ steps.release.outputs.tag_name }} \
-            --field release_version=${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }} \
-            --field commit_sha=${{ github.sha }}
+            --field release_tag=${{ steps.release.outputs.tag_name }}


### PR DESCRIPTION
## Summary

`release.yml` was passing `release_version` and `commit_sha` fields to `sync-agent-skills.yml` via `gh workflow run`, but those inputs are not declared in the target workflow since https://github.com/supabase-community/supabase-plugin/pull/25. Removed the two extra `--field` arguments since `sync-agent-skills.yml` only uses `release_tag`