### PR TITLE
docs(skills): verify email otp length in auth workflows

### DIFF
--- a/skills/supabase/SKILL.md
+++ b/skills/supabase/SKILL.md
@@ -18,6 +18,13 @@ First, fetch `https://supabase.com/changelog.md` (a lightweight summary index �
 **2. Verify your work.**
 After implementing any fix, run a test query to confirm the change works. A fix without verification is incomplete.
 
+For Auth email OTP template work, verify the configured code length end-to-end:
+
+- Confirm the client uses the OTP flow and the relevant email template renders `{{ .Token }}`.
+- Inspect `MAILER_OTP_LENGTH` / Dashboard **Authentication → Sign In / Providers → Email → Email OTP length**; do not infer the digit count from template wording alone.
+- Keep the backend OTP length, email copy (for example, "6-digit code"), UI input limit, and client-side validation in sync. Check OTP expiration copy against the configured expiry too.
+- After saving changes, request a fresh OTP and verify the emitted code length and sign-in flow.
+
 **3. Recover from errors, don't loop.**
 If an approach fails after 2-3 attempts, stop and reconsider. Try a different method, check documentation, inspect the error more carefully, and review relevant logs when available. Supabase issues are not always solved by retrying the same command, and the answer is not always in the logs, but logs are often worth checking before proceeding.
 


### PR DESCRIPTION
## What
- Add an Auth email OTP template verification checklist to the Supabase skill.
- Call out `MAILER_OTP_LENGTH` / Dashboard Email OTP length, template copy, UI input limits, and client-side validation alignment.
- Require requesting a fresh OTP after saving to verify the emitted digit count and sign-in flow.

## Why
- Prevent template wording from drifting from the configured OTP length when projects use non-default OTP lengths.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm test`
- `git diff --check`
- Manual grep confirmed checklist mentions `MAILER_OTP_LENGTH`, Email OTP length, client-side validation, and requesting a fresh OTP.

Fixes #107
