### PR TITLE
fix(release): keep skill versions and changelogs in sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,11 +54,11 @@ Skills follow the [Agent Skills Open Standard](https://agentskills.io/).
    "skills/{skill-name}": {
      "release-type": "simple",
      "skip-github-release": true,
-     "changelog-path": "skills/{skill-name}/CHANGELOG.md",
+     "changelog-path": "CHANGELOG.md",
      "extra-files": [
        {
          "type": "generic",
-         "path": "skills/{skill-name}/SKILL.md",
+         "path": "SKILL.md",
          "expressions": ["version: \"([0-9]+\\.[0-9]+\\.[0-9]+)\""]
        }
      ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ All commands must complete successfully.
 Releases are automated via [Release Please](https://github.com/googleapis/release-please). It tracks commits on `main` and opens a release PR when there are releasable changes.
 
 - Use conventional commit prefixes — `fix:` for a patch bump, `feat:` for a minor bump — so Release Please can determine the next version.
-- Release Please opens a release PR on `main` that bumps the repo version, updates the changelog, and bumps `metadata.version` in every skill's `SKILL.md` automatically. You do not need to bump skill versions manually.
+- Release Please opens a release PR on `main` that bumps the repo version, updates changelogs, and bumps `metadata.version` in changed skills' `SKILL.md` files automatically. You do not need to bump skill versions manually.
 - Merging the release PR triggers GitHub Actions to:
   1. Create a GitHub release and git tag (e.g. `v0.2.0`)
   2. Package each directory under `skills/` into its own `.tar.gz` and upload them as release assets
@@ -71,12 +71,12 @@ Releases are automated via [Release Please](https://github.com/googleapis/releas
 
 #### Adding a new skill
 
-When you add a new skill, register its `SKILL.md` in `release-please-config.json` under `extra-files` so Release Please keeps its `metadata.version` in sync. Without this, the tarball will still be built and shipped but the skill's version will never be bumped.
+When you add a new skill, register its `SKILL.md` in `release-please-config.json` under `extra-files` so Release Please keeps its `metadata.version` in sync. Package `changelog-path` and `extra-files` paths are relative to the package directory, not the repository root. Without this, the tarball will still be built and shipped but the skill's version will never be bumped.
 
 ```json
 {
   "type": "generic",
-  "path": "skills/my-skill/SKILL.md",
+  "path": "SKILL.md",
   "expressions": ["version: \"([0-9]+\\.[0-9]+\\.[0-9]+)\""]
 }
 ```

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,7 +20,7 @@
       "extra-files": [
         {
           "type": "generic",
-          "path": "skills/supabase/SKILL.md",
+          "path": "SKILL.md",
           "expressions": ["version: \"([0-9]+\\.[0-9]+\\.[0-9]+)\""]
         }
       ]
@@ -32,7 +32,7 @@
       "extra-files": [
         {
           "type": "generic",
-          "path": "skills/supabase-postgres-best-practices/SKILL.md",
+          "path": "SKILL.md",
           "expressions": ["version: \"([0-9]+\\.[0-9]+\\.[0-9]+)\""]
         }
       ]

--- a/skills/supabase-postgres-best-practices/CHANGELOG.md
+++ b/skills/supabase-postgres-best-practices/CHANGELOG.md
@@ -3,16 +3,9 @@
 ## [1.3.0](https://github.com/supabase/agent-skills/compare/v1.2.0...v1.3.0) (2026-06-05)
 
 
-### Features
-
-* add schema-constraints reference for safe migration patterns ([#30](https://github.com/supabase/agent-skills/issues/30)) ([9b236f3](https://github.com/supabase/agent-skills/commit/9b236f3ebd65d76a2c570f19931353da9c858d5a))
-* using Supabase agent skills ([#12](https://github.com/supabase/agent-skills/issues/12)) ([7c2e389](https://github.com/supabase/agent-skills/commit/7c2e3894fddfde8eb6c77d2a8921904543b9be7a))
-
-
 ### Bug Fixes
 
-* correct broken reference link in postgres best practices skill ([#58](https://github.com/supabase/agent-skills/issues/58)) ([f4e2277](https://github.com/supabase/agent-skills/commit/f4e22777fd8573537297b568c16e5a45a25927da))
-* cover SECURITY DEFINER, auth.role() deprecation, and BOLA in security checklist ([#85](https://github.com/supabase/agent-skills/issues/85)) ([133f43e](https://github.com/supabase/agent-skills/commit/133f43e8c2ffc48823ff0630c692cabecea3e3a3))
+* fix per-skill changelog path handling ([#101](https://github.com/supabase/agent-skills/issues/101)) ([7bfb444](https://github.com/supabase/agent-skills/commit/7bfb444edd42fb5029dcd650b73a2a8211639914))
 
 ## [1.2.0](https://github.com/supabase/agent-skills/compare/v1.1.1...v1.2.0) (2026-06-02)
 

--- a/skills/supabase-postgres-best-practices/SKILL.md
+++ b/skills/supabase-postgres-best-practices/SKILL.md
@@ -4,7 +4,7 @@ description: Postgres performance optimization and best practices from Supabase.
 license: MIT
 metadata:
   author: supabase
-  version: "1.1.1"
+  version: "1.3.0"
   organization: Supabase
   date: January 2026
   abstract: Comprehensive Postgres performance optimization guide for developers using Supabase and Postgres. Contains performance rules across 8 categories, prioritized by impact from critical (query performance, connection management) to incremental (advanced features). Each rule includes detailed explanations, incorrect vs. correct SQL examples, query plan analysis, and specific performance metrics to guide automated optimization and code generation.

--- a/skills/supabase/CHANGELOG.md
+++ b/skills/supabase/CHANGELOG.md
@@ -3,19 +3,9 @@
 ## [0.1.4](https://github.com/supabase/agent-skills/compare/v0.1.3...v0.1.4) (2026-06-05)
 
 
-### Features
-
-* add instructions to check changelog ([#74](https://github.com/supabase/agent-skills/issues/74)) ([4bb13d8](https://github.com/supabase/agent-skills/commit/4bb13d858d19f1f848505a66f46fc9603fdcde95))
-* add npm supply-chain security guidance to supabase skill ([#94](https://github.com/supabase/agent-skills/issues/94)) ([82df90a](https://github.com/supabase/agent-skills/commit/82df90a5de1cd84386d8bc192746e50343b86dc0))
-* instructions on exposing tables to the data api ([#71](https://github.com/supabase/agent-skills/issues/71)) ([f15a5a4](https://github.com/supabase/agent-skills/commit/f15a5a40779072a530c9e53c3f14ec4131118ea6))
-* using Supabase agent skills ([#12](https://github.com/supabase/agent-skills/issues/12)) ([7c2e389](https://github.com/supabase/agent-skills/commit/7c2e3894fddfde8eb6c77d2a8921904543b9be7a))
-
-
 ### Bug Fixes
 
-* bump supabase skill to v0.1.1 and fix Data API broken link ([#72](https://github.com/supabase/agent-skills/issues/72)) ([5a6542e](https://github.com/supabase/agent-skills/commit/5a6542e08fc026d90c9a6a0f5a67749e9ceb9946))
-* cover SECURITY DEFINER, auth.role() deprecation, and BOLA in security checklist ([#85](https://github.com/supabase/agent-skills/issues/85)) ([133f43e](https://github.com/supabase/agent-skills/commit/133f43e8c2ffc48823ff0630c692cabecea3e3a3))
-* update Data API doc link and bump supabase skill to v0.1.1 ([#73](https://github.com/supabase/agent-skills/issues/73)) ([e5f7a7c](https://github.com/supabase/agent-skills/commit/e5f7a7cfd697765848ffd6a4505f3c02e1ee17ee))
+* fix per-skill changelog path handling ([#101](https://github.com/supabase/agent-skills/issues/101)) ([7bfb444](https://github.com/supabase/agent-skills/commit/7bfb444edd42fb5029dcd650b73a2a8211639914))
 
 ## [0.1.3](https://github.com/supabase/agent-skills/compare/v0.1.2...v0.1.3) (2026-06-02)
 

--- a/skills/supabase/SKILL.md
+++ b/skills/supabase/SKILL.md
@@ -3,7 +3,7 @@ name: supabase
 description: "Use when doing ANY task involving Supabase. Triggers: Supabase products (Database, Auth, Edge Functions, Realtime, Storage, Vectors, Cron, Queues); client libraries and SSR integrations (supabase-js, @supabase/ssr) in Next.js, React, SvelteKit, Astro, Remix; auth issues (login, logout, sessions, JWT, cookies, getSession, getUser, getClaims, RLS); Supabase CLI or MCP server; schema changes, migrations, security audits, Postgres extensions (pg_graphql, pg_cron, pg_vector)."
 metadata:
   author: supabase
-  version: "0.1.2"
+  version: "0.1.4"
 ---
 
 # Supabase

--- a/test/sanity.test.ts
+++ b/test/sanity.test.ts
@@ -4,17 +4,37 @@ import {
 	existsSync,
 	mkdtempSync,
 	readdirSync,
+	readFileSync,
 	rmSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-const SKILLS_DIR = join(__dirname, "..", "skills");
+const REPO_ROOT = join(__dirname, "..");
+const SKILLS_DIR = join(REPO_ROOT, "skills");
+const RELEASE_PLEASE_CONFIG_PATH = join(REPO_ROOT, "release-please-config.json");
+const RELEASE_PLEASE_MANIFEST_PATH = join(
+	REPO_ROOT,
+	".release-please-manifest.json",
+);
 const PUBLIC_SKILL_NAMES = [
 	"supabase",
 	"supabase-postgres-best-practices",
 ] as const;
+
+type ReleasePleaseExtraFile = {
+	path: string;
+};
+
+type ReleasePleasePackageConfig = {
+	"changelog-path"?: string;
+	"extra-files"?: ReleasePleaseExtraFile[];
+};
+
+type ReleasePleaseConfig = {
+	packages: Record<string, ReleasePleasePackageConfig>;
+};
 
 type InstallResult = {
 	commandExitCode: number;
@@ -22,6 +42,19 @@ type InstallResult = {
 	installedSkillNames: string[];
 	installDir: string;
 };
+
+function readJsonFile<T>(path: string): T {
+	return JSON.parse(readFileSync(path, "utf-8")) as T;
+}
+
+function readSkillVersion(skillName: string): string {
+	const skillMd = readFileSync(join(SKILLS_DIR, skillName, "SKILL.md"), "utf-8");
+	const version = skillMd.match(/version: "([^"]+)"/)?.[1];
+	if (!version) {
+		throw new Error(`Missing metadata.version in ${skillName}/SKILL.md`);
+	}
+	return version;
+}
 
 /**
  * Dynamically discover all skill names from the skills/ directory
@@ -156,4 +189,63 @@ describe("skills add sanity check", () => {
 			).toBe(true);
 		}
 	});
+});
+
+describe("release metadata sanity check", () => {
+	const releasePleaseConfig = readJsonFile<ReleasePleaseConfig>(
+		RELEASE_PLEASE_CONFIG_PATH,
+	);
+	const releasePleaseManifest = readJsonFile<Record<string, string>>(
+		RELEASE_PLEASE_MANIFEST_PATH,
+	);
+
+	it.each(PUBLIC_SKILL_NAMES)(
+		"should resolve %s release files relative to the package directory",
+		(skillName) => {
+			const packagePath = `skills/${skillName}`;
+			const packageConfig = releasePleaseConfig.packages[packagePath];
+			expect(packageConfig, `Expected Release Please config for ${packagePath}`)
+				.toBeDefined();
+			if (!packageConfig) {
+				return;
+			}
+
+			const changelogPath = join(
+				REPO_ROOT,
+				packagePath,
+				packageConfig["changelog-path"] ?? "CHANGELOG.md",
+			);
+			expect(
+				existsSync(changelogPath),
+				`Expected changelog to exist at ${changelogPath}`,
+			).toBe(true);
+
+			const skillVersionUpdater = packageConfig["extra-files"]?.find(
+				(extraFile) => extraFile.path.endsWith("SKILL.md"),
+			);
+			expect(
+				skillVersionUpdater,
+				`Expected SKILL.md extra-file updater for ${packagePath}`,
+			).toBeDefined();
+			if (!skillVersionUpdater) {
+				return;
+			}
+
+			const skillMdPath = join(REPO_ROOT, packagePath, skillVersionUpdater.path);
+			expect(
+				existsSync(skillMdPath),
+				`Expected SKILL.md extra-file to resolve at ${skillMdPath}`,
+			).toBe(true);
+		},
+	);
+
+	it.each(PUBLIC_SKILL_NAMES)(
+		"should keep %s SKILL.md metadata.version in sync with the release manifest",
+		(skillName) => {
+			const packagePath = `skills/${skillName}`;
+			expect(readSkillVersion(skillName)).toBe(
+				releasePleaseManifest[packagePath],
+			);
+		},
+	);
 });


### PR DESCRIPTION
## Summary

- Fix Release Please per-skill `extra-files` paths so `SKILL.md` resolves relative to each skill package and `metadata.version` can be bumped by release PRs.
- Sync the current per-skill `SKILL.md` versions with `.release-please-manifest.json` and replace the duplicate latest changelog blocks with the actual release-tooling fix.
- Add sanity coverage for package-relative release files and manifest/SKILL.md version sync, and update the release config examples.

Fixes #106

## Tests

- `/Users/pwd/Library/pnpm/pnpm install --frozen-lockfile`
- `/Users/pwd/Library/pnpm/pnpm test`
- `GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=supabase/agent-skills RELEASE_TAG=v0.1.5 /Users/pwd/Library/pnpm/pnpm build:release`
- `git diff --check`
- release metadata smoke check: SKILL.md versions match the manifest, package-relative `extra-files` resolve, and latest changelog entries are not byte-identical
