### PR TITLE
fix: tighten VACUUM/ANALYZE monitoring guidance

### DIFF
--- a/skills/supabase-postgres-best-practices/references/monitor-vacuum-analyze.md
+++ b/skills/supabase-postgres-best-practices/references/monitor-vacuum-analyze.md
@@ -7,7 +7,7 @@ tags: vacuum, analyze, statistics, maintenance, autovacuum
 
 ## Maintain Table Statistics with VACUUM and ANALYZE
 
-Outdated statistics cause the query planner to make poor decisions. VACUUM reclaims space, ANALYZE updates statistics.
+Outdated statistics cause the query planner to make poor decisions. VACUUM reclaims dead tuples and makes space reusable; ANALYZE updates statistics.
 
 **Incorrect (stale statistics):**
 
@@ -34,9 +34,10 @@ select
   last_vacuum,
   last_autovacuum,
   last_analyze,
-  last_autoanalyze
+  last_autoanalyze,
+  greatest(last_analyze, last_autoanalyze) as last_analyzed
 from pg_stat_user_tables
-order by last_analyze nulls first;
+order by greatest(last_analyze, last_autoanalyze) nulls first;
 ```
 
 Autovacuum tuning for busy tables:
@@ -48,7 +49,7 @@ alter table orders set (
   autovacuum_analyze_scale_factor = 0.02     -- Analyze at 2% changes (default 10%)
 );
 
--- Check autovacuum status
+-- Inspect running vacuum/autovacuum activity
 select * from pg_stat_progress_vacuum;
 ```
 


### PR DESCRIPTION
Closes #118

## What

Three small correctness fixes to `skills/supabase-postgres-best-practices/references/monitor-vacuum-analyze.md`:

1. **VACUUM description** — plain `VACUUM` marks dead tuples reusable within the relation; it does not necessarily return disk to the OS (that's `VACUUM FULL`). Reworded from "reclaims space" to "reclaims dead tuples and makes space reusable".
2. **"Last analyzed" query** — `order by last_analyze` (and reading `last_analyze` alone) can surface an older *manual* ANALYZE even when autovacuum ran more recently. Switched to `greatest(last_analyze, last_autoanalyze)` in both the select list and the ordering.
3. **Autovacuum "status" label** — `pg_stat_progress_vacuum` only reports currently-running workers, so it's empty when nothing is running and doesn't describe overall status. Relabeled the snippet as a live vacuum/autovacuum activity check.

## Why

Each is a factual accuracy fix to generic Postgres guidance — nothing installation- or project-specific.

## Testing

Docs-only content change to a reference file: no frontmatter, heading, filename, or `_sections.md` changes. The sanity suite (`test/sanity.test.ts`) validates the `skills add` install flow and `SKILL.md` presence — it does not inspect reference bodies — so this change is orthogonal to it. CI will run `pnpm test`.

Surfaced during a downstream review of a repo that vendors this skill.
