### PR TITLE
chore: label skill release components

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,6 +15,7 @@
     },
     "skills/supabase": {
       "release-type": "simple",
+      "component": "supabase",
       "skip-github-release": true,
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
@@ -27,6 +28,7 @@
     },
     "skills/supabase-postgres-best-practices": {
       "release-type": "simple",
+      "component": "supabase-postgres-best-practices",
       "skip-github-release": true,
       "changelog-path": "CHANGELOG.md",
       "extra-files": [


### PR DESCRIPTION
Labels the two skill packages in Release Please so release PR dropdowns show which skill each version belongs to. In https://github.com/supabase/agent-skills/pull/122, the release body showed three unlabeled version dropdowns (two were skill version updates, one was a root package release that corresponds to the tag + GitHub release).

Before:

```text
▶︎ 0.1.6
▶︎ 0.1.5
▶︎ 1.4.0
```

After:

```text
▶︎ 0.1.6
▶︎ supabase: 0.1.5
▶︎ supabase-postgres-best-practices: 1.4.0
```

The root package remains unlabeled so existing `v0.x` GitHub release tag behavior is unchanged, but if desired we can label at too since IIUC the plugins sync workflow doesn't depend on a particular release tag name.

**References**
- https://github.com/googleapis/release-please/blob/main/src/util/pull-request-body.ts#L68-L78
