### PR TITLE
fix(supabase-postgres-best-practices): make skill description trigger-rich

### DIFF
--- a/skills/supabase-postgres-best-practices/SKILL.md
+++ b/skills/supabase-postgres-best-practices/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: supabase-postgres-best-practices
-description: Postgres performance optimization and best practices from Supabase. Use this skill when writing, reviewing, or optimizing Postgres queries, schema designs, or database configurations.
+description: "Postgres best practices maintained by Supabase, for Postgres running anywhere. Load this skill BEFORE writing or changing anything that lives in a Postgres database: creating or altering tables and columns (including choosing column types), schema design, migrations and declarative schema files, RLS policies and the tests that verify them, indexes, triggers, database functions, queues and scheduled jobs (pg_cron, pgmq), vector/semantic search (pgvector), and restoring dumps (pg_restore) or importing data. Also load it when diagnosing slow queries, high CPU, timeouts, EXPLAIN plans, connection exhaustion, locking, bloat, or rows visible to the wrong user or tenant. This is not just a performance guide — schema, migration, security, and SQL authoring tasks need these rules too, even for a one-column change or a single query."
 license: MIT
 metadata:
   author: supabase


### PR DESCRIPTION
Rewrites the `supabase-postgres-best-practices` skill description so it triggers on the full range of Postgres-authoring work — schema/table changes, migrations, RLS policies, indexes, triggers, functions — not just performance tuning, and leads with those concrete triggers. This improves activation when the skill coexists with the `supabase` skill.

**Scope:** one line — the `description:` frontmatter field. No body/behavior changes.

**Before**
> Postgres performance optimization and best practices from Supabase. Use this skill when writing, reviewing, or optimizing Postgres queries, schema designs, or database configurations.

**After**
> Postgres best practices maintained by Supabase, for Postgres running anywhere. Load this skill BEFORE writing or changing anything that lives in a Postgres database: creating or altering tables and columns … _(full text in the diff)_

Tested in https://github.com/supabase/evals/pull/131. Part of [AI-942](https://linear.app/supabase/issue/AI-942/tune-supabase-postgres-best-practices-activation).

---
_Note for re-review:_ an earlier revision of this branch also touched `skills/supabase/SKILL.md` (the account-deletion guidance). That has been **removed** from this PR and moved into the docs at [supabase/supabase#48487](https://github.com/supabase/supabase/pull/48487), so this PR is now scoped to the description change only. History was squashed to a single commit; @mattrossman a re-approve is needed.