### PR TITLE
fix: correct RLS helper execution privileges

### DIFF
--- a/skills/supabase-postgres-best-practices/references/security-rls-performance.md
+++ b/skills/supabase-postgres-best-practices/references/security-rls-performance.md
@@ -29,7 +29,7 @@ create policy orders_policy on orders
 
 Use security definer functions for complex checks:
 
-`SECURITY DEFINER` functions run with the creator's privileges and bypass RLS on any tables they touch — which is what makes them useful for internal lookups, but also what makes them dangerous if misused. Always include an explicit `auth.uid()` check inside the function body and keep helpers in a non-exposed schema. Revoke `EXECUTE` from roles that should not invoke the helper. Roles whose RLS policies evaluate through a stored helper still need `EXECUTE` on that exact function; `SECURITY DEFINER` does not remove that caller privilege check. Direct schema lookups normally require schema `USAGE`, but an RLS policy created with the helper already resolved stores the function OID, so the policy-calling role does not need schema-wide `USAGE` merely to evaluate that stored helper. Keeping schema `USAGE` revoked reduces unnecessary access to other private-schema objects.
+`SECURITY DEFINER` functions run with the creator's privileges and bypass RLS on any tables they touch — which is what makes them useful for internal lookups, but also what makes them dangerous if misused. Always include an explicit `auth.uid()` check inside the function body and keep helpers in a non-exposed schema. Revoke `EXECUTE` from roles that should not invoke the helper. Roles whose RLS policies evaluate through a stored helper still need `EXECUTE` on that exact function; `SECURITY DEFINER` does not remove that caller privilege check. Direct schema lookups normally require schema `USAGE`, but an RLS policy created with the helper already resolved stores the function OID, so the policy-calling role does not need schema-wide `USAGE` merely to evaluate that stored helper. Keep schema `USAGE` explicitly revoked for API roles so they cannot resolve unrelated private-schema objects.
 
 ```sql
 -- Create helper function in a private schema
@@ -46,12 +46,16 @@ as $$
   );
 $$;
 
--- Revoke broad/default execution; keep anonymous callers out
+-- Keep direct private-schema resolution unavailable to API roles
+revoke usage on schema private from PUBLIC;
+revoke usage on schema private from anon;
+revoke usage on schema private from authenticated;
+
+-- Remove broad/default helper execution
 revoke execute on function private.is_team_member(bigint) from PUBLIC;
 revoke execute on function private.is_team_member(bigint) from anon;
 
--- Grant only exact helper EXECUTE to the policy-calling role.
--- Do not grant schema-wide USAGE on private merely for this stored policy helper.
+-- Allow the stored RLS policy to execute only this helper
 grant execute on function private.is_team_member(bigint) to authenticated;
 
 -- Use in policy (indexed lookup, not per-row check)
@@ -60,9 +64,9 @@ create policy team_orders_policy on orders
   using ((select private.is_team_member(team_id)));
 ```
 
-Keep the helper schema out of PostgREST's exposed schemas. Omitting schema `USAGE` for `authenticated` does not prevent a stored RLS policy from calling the already-resolved helper; it only limits broader resolution of other private-schema objects.
+Keep the helper schema out of PostgREST's exposed schemas. With schema `USAGE` withheld, a direct `private.is_team_member(...)` call from `authenticated` fails, while a previously created RLS policy can still evaluate the stored helper OID when that role has exact-function `EXECUTE`.
 
-Verify the intended allowlist, then exercise the real policy role:
+Verify the intended allowlist, then exercise the real policy role with a representative JWT identity:
 
 ```sql
 begin;
@@ -78,12 +82,22 @@ select
   ) as can_execute_helper;
 -- Intended: can_use_private_schema = false, can_execute_helper = true
 
--- Exercise a query protected by the policy under this role
+-- Simulate an authenticated request identity for RLS validation
+select set_config(
+  'request.jwt.claims',
+  jsonb_build_object(
+    'role', 'authenticated',
+    'sub', '<member-user-uuid>'
+  )::text,
+  true
+);
+
 set local role authenticated;
--- select ... from orders; -- succeeds for an allowed member via the stored policy helper
+-- select ... from orders; -- returns member-visible row(s) via the stored policy helper
 
 rollback;
 ```
+
 Always add indexes on columns used in RLS policies:
 
 ```sql

--- a/skills/supabase-postgres-best-practices/references/security-rls-performance.md
+++ b/skills/supabase-postgres-best-practices/references/security-rls-performance.md
@@ -29,7 +29,7 @@ create policy orders_policy on orders
 
 Use security definer functions for complex checks:
 
-`SECURITY DEFINER` functions run with the creator's privileges and bypass RLS on any tables they touch — which is what makes them useful for internal lookups, but also what makes them dangerous if misused. Always include an explicit `auth.uid()` check inside the function body, keep them in a non-exposed schema, and revoke `EXECUTE` from any role that shouldn't call them directly.
+`SECURITY DEFINER` functions run with the creator's privileges and bypass RLS on any tables they touch — which is what makes them useful for internal lookups, but also what makes them dangerous if misused. Always include an explicit `auth.uid()` check inside the function body and keep helpers in a non-exposed schema. Revoke `EXECUTE` from roles that should not invoke the helper, but roles whose RLS policies evaluate through it still need schema `USAGE` and function `EXECUTE`. `SECURITY DEFINER` does not remove that caller privilege check.
 
 ```sql
 -- Create helper function in a private schema
@@ -46,12 +46,41 @@ as $$
   );
 $$;
 
--- Revoke direct execution from public roles
-revoke execute on function private.is_team_member(bigint) from PUBLIC, anon, authenticated, service_role;
+-- Revoke broad/default execution; keep anonymous callers out
+revoke execute on function private.is_team_member(bigint) from PUBLIC;
+revoke execute on function private.is_team_member(bigint) from anon;
+
+-- Authenticated policy evaluation still requires schema USAGE + EXECUTE
+grant usage on schema private to authenticated;
+grant execute on function private.is_team_member(bigint) to authenticated;
 
 -- Use in policy (indexed lookup, not per-row check)
 create policy team_orders_policy on orders
+  to authenticated
   using ((select private.is_team_member(team_id)));
+```
+
+Keep the helper schema out of PostgREST's exposed schemas. Schema `USAGE` for `authenticated` only allows PostgreSQL to resolve the helper during policy evaluation; it does not publish the schema through the Data API.
+
+Verify the allowlist under the real policy role before relying on application traffic:
+
+```sql
+begin;
+
+set local role authenticated;
+
+select
+  has_schema_privilege(current_user, 'private', 'USAGE') as can_use_private_schema,
+  has_function_privilege(
+    current_user,
+    'private.is_team_member(bigint)',
+    'EXECUTE'
+  ) as can_execute_helper;
+
+-- Also exercise a query protected by the policy under this role
+-- against your real application schema.
+
+rollback;
 ```
 
 Always add indexes on columns used in RLS policies:

--- a/skills/supabase-postgres-best-practices/references/security-rls-performance.md
+++ b/skills/supabase-postgres-best-practices/references/security-rls-performance.md
@@ -29,7 +29,7 @@ create policy orders_policy on orders
 
 Use security definer functions for complex checks:
 
-`SECURITY DEFINER` functions run with the creator's privileges and bypass RLS on any tables they touch — which is what makes them useful for internal lookups, but also what makes them dangerous if misused. Always include an explicit `auth.uid()` check inside the function body and keep helpers in a non-exposed schema. Revoke `EXECUTE` from roles that should not invoke the helper, but roles whose RLS policies evaluate through it still need schema `USAGE` and function `EXECUTE`. `SECURITY DEFINER` does not remove that caller privilege check.
+`SECURITY DEFINER` functions run with the creator's privileges and bypass RLS on any tables they touch — which is what makes them useful for internal lookups, but also what makes them dangerous if misused. Always include an explicit `auth.uid()` check inside the function body and keep helpers in a non-exposed schema. Revoke `EXECUTE` from roles that should not invoke the helper. Roles whose RLS policies evaluate through a stored helper still need `EXECUTE` on that exact function; `SECURITY DEFINER` does not remove that caller privilege check. Direct schema lookups normally require schema `USAGE`, but an RLS policy created with the helper already resolved stores the function OID, so the policy-calling role does not need schema-wide `USAGE` merely to evaluate that stored helper. Keeping schema `USAGE` revoked reduces unnecessary access to other private-schema objects.
 
 ```sql
 -- Create helper function in a private schema
@@ -50,8 +50,8 @@ $$;
 revoke execute on function private.is_team_member(bigint) from PUBLIC;
 revoke execute on function private.is_team_member(bigint) from anon;
 
--- Authenticated policy evaluation still requires schema USAGE + EXECUTE
-grant usage on schema private to authenticated;
+-- Grant only exact helper EXECUTE to the policy-calling role.
+-- Do not grant schema-wide USAGE on private merely for this stored policy helper.
 grant execute on function private.is_team_member(bigint) to authenticated;
 
 -- Use in policy (indexed lookup, not per-row check)
@@ -60,29 +60,30 @@ create policy team_orders_policy on orders
   using ((select private.is_team_member(team_id)));
 ```
 
-Keep the helper schema out of PostgREST's exposed schemas. Schema `USAGE` for `authenticated` only allows PostgreSQL to resolve the helper during policy evaluation; it does not publish the schema through the Data API.
+Keep the helper schema out of PostgREST's exposed schemas. Omitting schema `USAGE` for `authenticated` does not prevent a stored RLS policy from calling the already-resolved helper; it only limits broader resolution of other private-schema objects.
 
-Verify the allowlist under the real policy role before relying on application traffic:
+Verify the intended allowlist, then exercise the real policy role:
 
 ```sql
 begin;
 
-set local role authenticated;
-
+-- Inspect privileges for the policy role (named lookup needs a privileged session
+-- when private schema USAGE is intentionally withheld)
 select
-  has_schema_privilege(current_user, 'private', 'USAGE') as can_use_private_schema,
+  has_schema_privilege('authenticated', 'private', 'USAGE') as can_use_private_schema,
   has_function_privilege(
-    current_user,
+    'authenticated',
     'private.is_team_member(bigint)',
     'EXECUTE'
   ) as can_execute_helper;
+-- Intended: can_use_private_schema = false, can_execute_helper = true
 
--- Also exercise a query protected by the policy under this role
--- against your real application schema.
+-- Exercise a query protected by the policy under this role
+set local role authenticated;
+-- select ... from orders; -- succeeds for an allowed member via the stored policy helper
 
 rollback;
 ```
-
 Always add indexes on columns used in RLS policies:
 
 ```sql


### PR DESCRIPTION
## Summary

* corrects the RLS SECURITY DEFINER helper example so API roles do not receive `USAGE` on the private helper schema
* explicitly revokes private-schema `USAGE` from `PUBLIC`, `anon`, and `authenticated`
* grants `EXECUTE` only on the exact helper required by the authenticated RLS policy
* scopes the example policy to `authenticated`
* preserves the private/non-exposed schema, explicit `auth.uid()` check, `SECURITY DEFINER`, and fixed empty `search_path`
* adds real-role privilege checks plus JWT-identity RLS verification

Fixes #290

## Validation

* `pnpm test` — PASS
* disposable PostgreSQL 17 proof — PASS
  * authenticated schema `USAGE` denied; exact helper `EXECUTE` allowed
  * direct private-schema helper invocation denied (`permission denied for schema private`)
  * stored RLS policy succeeds for a member JWT identity
  * non-member remains filtered
  * anon remains denied
  * helper retains `SECURITY DEFINER`, empty `search_path`, and `auth.uid()` identity check

Made with [Cursor](https://cursor.com)