### PR TITLE
fix(supabase): require jit=true for Temporary Access pooler

### DIFF
--- a/skills/supabase/SKILL.md
+++ b/skills/supabase/SKILL.md
@@ -90,6 +90,11 @@ supabase <group> <command> --help  # Flags for a specific command
 - `supabase db advisors` requires **CLI v2.81.3+** → use MCP `get_advisors` as fallback
 - In imperative migration projects, create new hand-authored migration files with `supabase migration new <name>` first. Never invent a migration filename or rely on memory for the expected format. Declarative schema projects generate migrations from `supabase/schemas/`; see "Making and Committing Schema Changes" below.
 
+**Temporary Access / shared Session pooler gotchas:**
+
+- **Use literal `jit=true`, not `jit=on`.** Temporary Access over the shared Supavisor Session pooler activates only when the startup option value is the literal string `true` (for example `options='-c jit=true'` in conninfo, `options=-c%20jit%3Dtrue` in a URI, or `--jit=true`). Postgres-style `jit=on` does **not** enable Temporary Access JIT. See [Temporary access](https://supabase.com/docs/guides/platform/temporary-access.md) and the Supavisor parser/tests.
+- **Qualify the pooler username with the project ref.** Shared Session pooler usernames are `<role>.<project-ref>` (for example `postgres.<project-ref>`). Do not use the bare role name (`postgres`) from a direct `db.<project-ref>.supabase.co` connection string.
+
 **Version check and upgrade:** Run `supabase --version` to check. For CLI changelogs and version-specific features, consult the [CLI documentation](https://supabase.com/docs/reference/cli/introduction) or [GitHub releases](https://github.com/supabase/cli/releases).
 
 ## Supabase MCP Server


### PR DESCRIPTION
## Summary
- Warn that Temporary Access over the shared Supavisor Session pooler requires literal `jit=true` (not Postgres-style `jit=on`)
- Note shared pooler usernames must be `<role>.<project-ref>`
- Link the Temporary Access docs for the canonical examples

Fixes #311

## Testing
- Docs-only change to `skills/supabase/SKILL.md`; no runtime tests required