### PR TITLE
fix: discover hosted database connection fallbacks

### DIFF
--- a/skills/supabase/SKILL.md
+++ b/skills/supabase/SKILL.md
@@ -96,6 +96,14 @@ supabase <group> <command> --help  # Flags for a specific command
 
 For setup instructions, server URL, and configuration, see the [MCP setup guide](https://supabase.com/docs/guides/getting-started/mcp).
 
+**Choose an available database path before declaring a connection blocker:**
+
+1. Inspect the tools and authenticated connectors already available in the current environment. Project-scoped Supabase MCP tools may be lazily exposed rather than listed up front.
+2. Prefer a project-scoped MCP `execute_sql` tool when the task requires SQL. For table-level reads or writes, an authenticated Data API client is also valid; use guarded, idempotent mutations and verify affected rows.
+3. Use a direct PostgreSQL client only with a PostgreSQL connection string beginning with `postgres://` or `postgresql://`. A URL such as `https://<project-ref>.supabase.co` is a Supabase API URL, not a PostgreSQL DSN, even if it is stored under a misleading environment-variable name.
+4. Never print or move a `service_role` key into a public client while changing connection paths.
+5. Treat the database operation as blocked only after the relevant direct PostgreSQL, project-scoped MCP, and authenticated Data API paths are unavailable or fail bounded checks.
+
 **Troubleshooting connection issues** — follow these steps in order:
 
 1. **Check if the server is reachable:**


### PR DESCRIPTION
## Summary

- discover project-scoped Supabase SQL and authenticated Data API connectors before declaring a hosted database operation blocked
- distinguish HTTPS project API URLs from PostgreSQL DSNs
- preserve service-role secrecy and require bounded verification across fallback paths

## Validation

- `corepack pnpm test` — 7/7 passed
- Node 22 Vitest run — 7/7 passed
- skill-creator structural validation — valid
- `git diff --check` — clean

Fixes #393