### PR TITLE
fix(postgres): RLS helper example revoked EXECUTE from roles that evaluate the policy

### DIFF
--- a/skills/supabase-postgres-best-practices/references/security-rls-performance.md
+++ b/skills/supabase-postgres-best-practices/references/security-rls-performance.md
@@ -31,6 +31,8 @@ Use security definer functions for complex checks:
 
 `SECURITY DEFINER` functions run with the creator's privileges and bypass RLS on any tables they touch — which is what makes them useful for internal lookups, but also what makes them dangerous if misused. Always include an explicit `auth.uid()` check inside the function body, keep them in a non-exposed schema, and revoke `EXECUTE` from any role that shouldn't call them directly.
 
+One exception to keep in mind: a role evaluating an RLS policy needs `EXECUTE` on every function that policy references, because Postgres evaluates the policy expression with the calling role's privileges. Revoking `EXECUTE` from a role whose queries can trigger the policy breaks its queries with `permission denied for function ...` (SQLSTATE 42501). The pattern below revokes from `PUBLIC` to block uninvited direct calls, then grants `EXECUTE` only to the roles that legitimately evaluate the policy:
+
 ```sql
 -- Create helper function in a private schema
 create or replace function private.is_team_member(team_id bigint)
@@ -46,13 +48,28 @@ as $$
   );
 $$;
 
--- Revoke direct execution from public roles
-revoke execute on function private.is_team_member(bigint) from PUBLIC, anon, authenticated, service_role;
+-- Block direct calls from everyone first ...
+revoke execute on function private.is_team_member(bigint) from PUBLIC;
+
+-- ... then grant EXECUTE back to exactly the roles whose queries
+-- evaluate this policy. authenticated users query orders, so they need it.
+grant execute on function private.is_team_member(bigint) to authenticated;
+
+-- If an anon-facing policy on this table also calls the helper,
+-- anon needs EXECUTE too; likewise service_role for server-side paths.
+-- grant execute on function private.is_team_member(bigint) to anon;
+-- grant execute on function private.is_team_member(bigint) to service_role;
+
+-- Internal helpers reached ONLY through other definer functions or
+-- triggers (never referenced by a policy or view) can stay fully revoked:
+-- no role evaluates them directly.
 
 -- Use in policy (indexed lookup, not per-row check)
 create policy team_orders_policy on orders
   using ((select private.is_team_member(team_id)));
 ```
+
+The same rule applies to functions called inside view definitions: a role selecting through the view needs `EXECUTE` on those functions as well (`security_invoker` views evaluate with the querying role's privileges; definer views with the owner's, which usually already holds the grant). When queries start failing with 42501 after a hardening pass, check whether a recently revoked helper is referenced by a live policy or view before assuming the revoke was wrong — restore the narrowly scoped grant instead of dropping the helper from the policy.
 
 Always add indexes on columns used in RLS policies:
 


### PR DESCRIPTION
## Summary

Fixes the bug reported in #390: the `SECURITY DEFINER` helper example in `security-rls-performance.md` revoked `EXECUTE` from **all** roles — including `authenticated` and `service_role` — and then used that same function inside an RLS policy.

Postgres evaluates policy expressions with the calling role's privileges, so any role whose queries can trigger the policy needs `EXECUTE` on every function the policy references. Following the previous example verbatim caused every authenticated query against the protected table to fail with:

```
permission denied for function private.is_team_member (SQLSTATE 42501)
```

## What changed

- The example now revokes from `PUBLIC` only (which blocks uninvited direct calls — the actual security goal), then explicitly grants `EXECUTE` back to the roles that legitimately evaluate the policy (`authenticated`; commented examples for `anon`/`service_role` when their policies reference the helper).
- Added a short explanation of *why* the grant-back is required, so agents following the skill don't "fix" a 42501 by removing the revoke target from the policy or widening grants to everyone.
- Noted that internal helpers reached only through other definer functions/triggers — never referenced by a live policy or view — can remain fully revoked.
- Added the parallel rule for functions called inside view definitions, since the same failure mode shows up there.

## Why this matters for agents specifically

An agent following the old example produces a project where auth appears "broken" after a security hardening pass. The shortest recovery path an agent typically takes is removing the hardening entirely. The corrected example gives agents a pattern that hardens correctly on the first pass and a diagnostic hint (42501 → check policy/view references) when it doesn't.
