### PR TITLE
fix: discover ambiguous hosted project identities

### DIFF
--- a/skills/supabase/SKILL.md
+++ b/skills/supabase/SKILL.md
@@ -96,6 +96,13 @@ supabase <group> <command> --help  # Flags for a specific command
 
 For setup instructions, server URL, and configuration, see the [MCP setup guide](https://supabase.com/docs/guides/getting-started/mcp).
 
+**Hosted project identity preflight** — Before asking the user to choose a project or performing any target-dependent hosted operation, identify the target using only read-only evidence:
+
+1. Read, but do not create or change, any existing `supabase/.temp/project-ref` and MCP `project_ref`; inspect current repository handoffs and migrations. Treat older repository refs as historical evidence, not the current target.
+2. With account-level MCP, use `list_projects`, then `get_project`, `get_project_url`, and `list_migrations` for viable candidates. With project-scoped MCP, where account tools are unavailable, verify its configured ref using the available project tools. Otherwise use read-only CLI equivalents discovered via `--help`.
+3. Reconcile project name/purpose, ref, URL, status, and migration ledger. If one non-production target is uniquely supported, report it with the evidence; identification is not mutation authorization.
+4. Never infer a production target or mutate during this preflight. Obtain separate authorization before any hosted mutation. Ask the user to identify the target only if access is unavailable or zero or multiple viable targets remain, and present recognizable names/purposes rather than refs alone.
+
 **Troubleshooting connection issues** — follow these steps in order:
 
 1. **Check if the server is reachable:**


### PR DESCRIPTION
## Summary

- add a read-only hosted project identity preflight before target-dependent Supabase operations
- distinguish account-level MCP discovery from project-scoped verification and CLI fallback
- reconcile recognizable project evidence while preserving a separate authorization boundary for hosted mutations

## Validation

- `pnpm install --frozen-lockfile` with Node 22.23.2 and pnpm 10.33.0
- `pnpm test` — 1 test file passed, 7 tests passed
- independent forward check against stale non-production, current non-production, and production project candidates

Closes #415