### PR TITLE
fix(supabase): clarify estimated table counts

### DIFF
--- a/skills/supabase/SKILL.md
+++ b/skills/supabase/SKILL.md
@@ -18,6 +18,8 @@ First, fetch `https://supabase.com/changelog.md` (a lightweight summary index â€
 **2. Verify your work.**
 After implementing any fix, run a test query to confirm the change works. A fix without verification is incomplete.
 
+Treat the Supabase MCP `list_tables` `rows` value as an approximate or stale table statistic, not a live row count. When exact cardinality affects an answer or migration decision, run `select count(*)` against the explicitly selected project and schema instead.
+
 **3. Recover from errors, don't loop.**
 If an approach fails after 2-3 attempts, stop and reconsider. Try a different method, check documentation, inspect the error more carefully, and review relevant logs when available. Supabase issues are not always solved by retrying the same command, and the answer is not always in the logs, but logs are often worth checking before proceeding.
 


### PR DESCRIPTION
## Summary

- clarify that MCP `list_tables.rows` is approximate or potentially stale metadata
- require an explicit `count(*)` query when exact cardinality affects an answer or migration decision
- require selecting the intended project and schema for the exact query

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm test` — 1 test file passed, 7 tests passed
- `git diff --check upstream/main...HEAD`
- exact guidance checks for estimated metadata and direct cardinality verification

Fixes #384
