### PR TITLE
fix(supabase): verify storage upload limits

### DIFF
--- a/skills/supabase/SKILL.md
+++ b/skills/supabase/SKILL.md
@@ -68,6 +68,7 @@ When working on any Supabase task that touches auth, RLS, views, storage, or use
 
 - **Storage access control**
   - **Storage upsert requires INSERT + SELECT + UPDATE.** Granting only INSERT allows new uploads but file replacement (upsert) silently fails. You need all three.
+  - **Check the global file size limit before changing a bucket limit or diagnosing HTTP 413 errors.** Confirm that the project's plan and global Storage limit allow the requested size, then set or remove the per-bucket limit without exceeding the global limit. Use resumable TUS or S3 uploads for files larger than 6 MB, and verify the change with a file larger than the previous limit while recording the Storage response status.
 
 - **Dependency and supply-chain security**
   - **Always pin package versions and commit lockfiles** when installing Supabase packages (`supabase-js`, `@supabase/ssr`, `supabase-py`, etc.). See the [npm security guide](https://supabase.com/docs/guides/security/npm-security.md) for the full checklist.


### PR DESCRIPTION
## Summary

- require checking the project-wide Storage limit before changing a bucket limit or diagnosing HTTP 413 failures
- keep per-bucket limits within the plan-supported global limit
- require an appropriate large-file upload protocol and verification above the previous ceiling

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm test` — 1 test file passed, 7 tests passed
- `git diff --check upstream/main...HEAD`
- exact guidance checks for global and bucket limits, TUS/S3 uploads, and above-limit verification

Fixes #400
