### PR TITLE
fix(supabase): require dependency check before revoking EXECUTE on helpers used by RLS

### DIFF
--- a/skills/supabase/SKILL.md
+++ b/skills/supabase/SKILL.md
@@ -65,6 +65,15 @@ When working on any Supabase task that touches auth, RLS, views, storage, or use
     ```
   - **`SECURITY DEFINER` functions bypass RLS.** A `SECURITY DEFINER` function runs with its creator's privileges — typically a role with `bypassrls` (e.g., `postgres`). Never add `SECURITY DEFINER` to resolve a permission error; it silently removes access control without fixing the underlying cause. Prefer `SECURITY INVOKER`.
   - **`SECURITY DEFINER` functions in `public` are callable by all roles.** Postgres grants `EXECUTE` to `PUBLIC` by default for every new function, so any `SECURITY DEFINER` function in `public` is a public API endpoint callable by `anon` and `authenticated` (which inherit from `PUBLIC`) without any additional grant. When `SECURITY DEFINER` is genuinely needed (e.g., bypassing RLS on an internal lookup table), keep the function in a non-exposed schema, always include an `auth.uid()` check in the function body, and run `supabase db advisors` after making changes.
+  - **Check RLS dependencies before revoking `EXECUTE`.** RLS policy expressions (`qual` / `with_check`) run with the querying user's privileges, so any role whose policies call a helper function still needs `EXECUTE` on it — even after the helper moves out of the exposed schema or is never called directly by client code. Revoking it anyway breaks every dependent policy at runtime with `permission denied for function`, which can take out multiple tables at once. Before recommending or applying a revoke, enumerate dependents and test under the real roles:
+    ```sql
+    -- find policies that evaluate the helper in either expression slot
+    select schemaname, tablename, policyname
+    from pg_policies
+    where qual ilike '%helper_name%'
+       or with_check ilike '%helper_name%';
+    ```
+    Also check views, triggers, and other functions that call the helper. Verify the proposed revoke inside a transaction as `anon`/`authenticated` and roll it back; if policies depend on the helper, update the policies and the privilege change in the same migration.
 
 - **Storage access control**
   - **Storage upsert requires INSERT + SELECT + UPDATE.** Granting only INSERT allows new uploads but file replacement (upsert) silently fails. You need all three.


### PR DESCRIPTION
﻿Fixes #412

## What

Adds one bullet to the "RLS, views, and privileged database code" group of the security checklist in `skills/supabase/SKILL.md`: before recommending or applying `REVOKE EXECUTE` on a function (especially a `SECURITY DEFINER` helper), enumerate dependent RLS policies (`pg_policies.qual` / `with_check`), check views/triggers/callers, and verify inside a rolled-back transaction as the real roles.

## Why

The checklist currently explains that `SECURITY DEFINER` functions are callable by all roles and advises keeping them out of exposed schemas, but it never warns that policy expressions run with the querying user's privileges. An agent following the checklist can revoke `EXECUTE` from a membership-predicate helper and silently break every policy that references it - which is exactly the failure reported in #412 (`permission denied for function` across multiple RLS-protected tables).

## Notes

- The added SQL snippet matches what the issue suggests (search both expression slots in `pg_policies`).
- Sibling example fix for the same failure class is in #409.
- `pnpm test`: 7 passed.
