### PR TITLE
fix: verify hosted Auth signup configuration

### DIFF
--- a/skills/supabase/SKILL.md
+++ b/skills/supabase/SKILL.md
@@ -18,6 +18,13 @@ First, fetch `https://supabase.com/changelog.md` (a lightweight summary index â€
 **2. Verify your work.**
 After implementing any fix, run a test query to confirm the change works. A fix without verification is incomplete.
 
+For signup/registration work, also verify hosted Auth â€” a database trigger or test can succeed while the Auth endpoint still returns `422 signup_disabled`:
+1. Confirm the email provider and new-user signup are enabled on the hosted project.
+2. Confirm email confirmation and Site URL / redirect behavior.
+3. Execute one real signup against the target hosted project.
+4. Verify the resulting Auth user and expected application profile/role provisioning.
+5. Clean up the synthetic test account.
+
 **3. Recover from errors, don't loop.**
 If an approach fails after 2-3 attempts, stop and reconsider. Try a different method, check documentation, inspect the error more carefully, and review relevant logs when available. Supabase issues are not always solved by retrying the same command, and the answer is not always in the logs, but logs are often worth checking before proceeding.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix / documentation guidance update.

## What is the current behavior?

The Supabase skill currently recommends verifying changes with a test query, but this can be insufficient for hosted Auth signup flows. Database-level verification may succeed while the hosted Auth endpoint still rejects registration, for example, with 422 signup_disabled.

Fixes #445

## What is the new behavior?

For signup/registration work, the skill now instructs agents to do the following:

- Confirm the email provider and new-user signup are enabled on the hosted project.
- Confirm email confirmation and Site URL / redirect behavior.
- Execute a real signup against the target hosted project.
- Verify the resulting Auth user and expected application profile/role provisioning.
- Clean up the synthetic test account.

This ensures hosted Auth behavior is verified in addition to database-level checks.

## Additional context

Validation completed successfully with:

`pnpm test`

All 7 tests passed.


