### PR TITLE
feat(supabase-postgres-best-practices): add lock_timeout and index name-collision references

### DIFF
--- a/skills/supabase-postgres-best-practices/references/lock-migration-timeout.md
+++ b/skills/supabase-postgres-best-practices/references/lock-migration-timeout.md
@@ -1,0 +1,56 @@
+---
+title: Set lock_timeout Before Running Schema-Changing Migrations
+impact: MEDIUM-HIGH
+impactDescription: Aborts a stuck migration in seconds instead of blocking all reads and writes until it is manually killed
+tags: locking, migrations, ddl, lock-timeout, rls
+---
+
+## Set lock_timeout Before Running Schema-Changing Migrations
+
+DDL that changes table metadata -- `CREATE POLICY`, `DROP POLICY`, most forms of `ALTER TABLE`, `CREATE TRIGGER` -- takes an `ACCESS EXCLUSIVE` lock, which blocks every concurrent reader and writer on that table until the migration's transaction commits. Without a `lock_timeout`, a migration that can't immediately acquire the lock waits indefinitely instead of failing fast.
+
+**Incorrect (no lock_timeout, waits indefinitely):**
+
+```sql
+begin;
+
+create policy orders_owner_policy on orders
+  for select
+  using ((select auth.uid()) = user_id);
+
+commit;
+
+-- If any other transaction already holds so much as a row lock on
+-- orders, this migration queues behind it waiting for ACCESS EXCLUSIVE --
+-- and every write to orders queues behind the migration in turn. A
+-- webhook handler updating an order times out, its caller retries, and
+-- the retries pile up behind the same lock until the migration finally
+-- commits or someone kills it manually.
+```
+
+**Correct (fails fast instead of blocking traffic):**
+
+```sql
+begin;
+
+-- Give up after 3s if the lock can't be acquired. Policy and trigger DDL
+-- is metadata-only and normally acquires the lock in well under a second
+-- on a healthy table, so 3s is generous headroom, not a tight budget.
+set local lock_timeout = '3s';
+
+create policy orders_owner_policy on orders
+  for select
+  using ((select auth.uid()) = user_id);
+
+commit;
+
+-- On timeout: ERROR:  canceling statement due to lock timeout
+-- The migration fails loudly and rolls back -- no blocked reads, no
+-- queued writers, no retry storm. Re-run once the blocking session clears.
+```
+
+A common misconception: connecting as `service_role` or a superuser does not help. Those roles bypass **RLS policy evaluation** -- which rows are visible -- not the **table-level lock** the DDL itself takes, which Postgres enforces regardless of the connecting role. Running the migration through a session-mode vs. transaction-mode pooler makes no difference either; lock semantics are identical at the database level in both cases.
+
+`lock_timeout` only bounds how long the migration waits to *acquire* the lock, not how long the DDL runs once granted -- reserve a longer timeout (or a maintenance window) for statements that actually rewrite table data, such as adding a column with a volatile default or changing a column's type. `set local` scopes the timeout to the current transaction so it can't leak into the session that runs the next migration.
+
+Reference: [lock_timeout (Client Connection Defaults)](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-LOCK-TIMEOUT)

--- a/skills/supabase-postgres-best-practices/references/query-index-name-collision.md
+++ b/skills/supabase-postgres-best-practices/references/query-index-name-collision.md
@@ -1,0 +1,55 @@
+---
+title: Verify Index Definitions Before Trusting CREATE INDEX IF NOT EXISTS
+impact: HIGH
+impactDescription: Same 10-100x cost as a missing index, but silent -- the migration exits 0 while the intended index was never created
+tags: indexes, migrations, idempotency, query-optimization
+---
+
+## Verify Index Definitions Before Trusting CREATE INDEX IF NOT EXISTS
+
+`CREATE INDEX IF NOT EXISTS <name> ON ...` only checks whether an index with that literal *name* already exists -- it never compares the existing index's definition (columns, expression, partial predicate) to the one being created. If the name collides with an unrelated index from an earlier migration or a manual hotfix, the statement silently no-ops: exit code 0, no error, no warning, and the index actually intended is never created.
+
+**Incorrect (name collision silently swallowed):**
+
+```sql
+-- An earlier migration (or a manual hotfix run directly against the
+-- database) already created an index under this name, on a different column
+create index orders_status_idx on orders (created_at);
+
+-- A later migration intends to index `status` and reuses the same name...
+create index if not exists orders_status_idx on orders (status);
+-- ...and silently does nothing. orders_status_idx still indexes
+-- created_at, not status. Exit code 0 -- the migration "passes".
+
+select * from orders where status = 'pending';
+-- Still a sequential scan: the index this query needed was never created
+```
+
+**Correct (verify the live definition, then use a name guaranteed unique):**
+
+```sql
+-- Check what's actually live before trusting the name
+select indexdef from pg_indexes
+where schemaname = 'public' and indexname = 'orders_status_idx';
+-- indexdef: CREATE INDEX orders_status_idx ON public.orders USING btree (created_at)
+-- Confirms the name is already taken by a different index -- pick a new one
+
+create index if not exists orders_status_idx_v2 on orders (status);
+
+select * from orders where status = 'pending';
+-- Index Scan using orders_status_idx_v2
+```
+
+Alternative: give the index a name unique to its exact definition so a genuine collision raises a real, visible error instead of a silent no-op:
+
+```sql
+create index orders_status_pending_idx on orders (status)
+where status = 'pending';
+-- ERROR:  relation "orders_status_pending_idx" already exists
+-- A real collision is caught immediately, not discovered months later
+-- when the query it was supposed to speed up is still slow
+```
+
+Never assume a migration's success implies the intended schema is now live -- `IF NOT EXISTS` guarantees the statement didn't error, not that it did what you meant. When a name isn't provably unique to this migration, verify against `pg_indexes` (or `\d <table>` in `psql`) first.
+
+Reference: [pg_indexes](https://www.postgresql.org/docs/current/view-pg-indexes.html)


### PR DESCRIPTION
## What

Two new reference files for `supabase-postgres-best-practices`:

- `references/lock-migration-timeout.md` — always set `lock_timeout` before DDL that takes `ACCESS EXCLUSIVE` (policy changes, most `ALTER TABLE` forms, triggers), so a migration that can't immediately acquire the lock fails fast instead of blocking every concurrent reader and writer on the table until it commits.
- `references/query-index-name-collision.md` — `CREATE INDEX IF NOT EXISTS <name>` only checks the index *name*, never its definition. A name collision with a differently-defined index (from an earlier migration or a manual hotfix) makes the statement silently no-op — exit 0, no error — while the index actually needed is never created.

## Why these aren't already covered

Searched the existing 31 reference files for `lock_timeout`, `ACCESS EXCLUSIVE`, and `IF NOT EXISTS`. Two incidental hits (`lock-deadlock-prevention.md`, `schema-constraints.md`) — both confirmed on a full read to be unrelated (same words, different context; neither covers migration-time lock discipline or the index name-collision hazard). Both new files follow `_template.md`'s frontmatter and Incorrect/Correct structure, matching the SQL casing and tone of the existing `lock-*.md` / `query-*.md` files.

## Testing

`pnpm test` passes (7/7). No changes to `release-please-config.json` — per `CONTRIBUTING.md`, that registration step applies to a new *skill*, not new reference files under an existing one; these ship inside the skill's tarball on the next release like every other reference file.
