### PR TITLE
fix(postgres-best-practices): repoint two 404 reference links

### DIFF
--- a/skills/supabase-postgres-best-practices/references/data-pagination.md
+++ b/skills/supabase-postgres-best-practices/references/data-pagination.md
@@ -47,4 +47,4 @@ order by created_at, id
 limit 20;
 ```
 
-Reference: [Pagination](https://supabase.com/docs/guides/database/pagination)
+Reference: [LIMIT and OFFSET](https://www.postgresql.org/docs/current/queries-limit.html)

--- a/skills/supabase-postgres-best-practices/references/monitor-vacuum-analyze.md
+++ b/skills/supabase-postgres-best-practices/references/monitor-vacuum-analyze.md
@@ -52,4 +52,4 @@ alter table orders set (
 select * from pg_stat_progress_vacuum;
 ```
 
-Reference: [VACUUM](https://supabase.com/docs/guides/database/database-size#vacuum-operations)
+Reference: [VACUUM](https://supabase.com/docs/guides/platform/database-size#vacuum-operations)


### PR DESCRIPTION
Two `Reference:` links in the `supabase-postgres-best-practices` skill return 404 after the Supabase docs restructure, as reported in #493. These links are what an agent fetches to verify the guidance, so a dead link means the agent either fails the fetch or wanders off to an unrelated page. This PR repoints both links to live pages and changes nothing else.

The database-size page moved from `guides/database/` to `guides/platform/`; the `### Vacuum operations` section and its anchor still exist on the new page, so the fix is a path change only. The Supabase pagination guide was removed outright with no successor in the docs sitemap or `llms.txt`, so that link now points at the Postgres `LIMIT` and `OFFSET` docs, which state that rows skipped by `OFFSET` are still computed server-side. That is exactly the claim the reference file makes, and the skill already cites postgresql.org in the same `Reference:` style in several other files.

## Links

| File | Old URL | Old status | New URL | New status |
| --- | --- | --- | --- | --- |
| `references/monitor-vacuum-analyze.md` | https://supabase.com/docs/guides/database/database-size#vacuum-operations | 404 | https://supabase.com/docs/guides/platform/database-size#vacuum-operations | 200 |
| `references/data-pagination.md` | https://supabase.com/docs/guides/database/pagination | 404 | https://www.postgresql.org/docs/current/queries-limit.html | 200 |

Status codes observed with `curl -sIL -o /dev/null -w "%{http_code}"` on 2026-09-03; old URLs also 404 in their `.md` form. A repo-wide grep found no other occurrences of either old URL.

## Checks

- `pnpm test`: the 3 structural tests pass. The 4 `skills add` install tests fail identically on an untouched `upstream/main` checkout in my environment, so that failure is local and unrelated to this change.

Fixes #493
