### PR TITLE
fix(supabase): honor repository-specific access contracts

### DIFF
--- a/skills/supabase/SKILL.md
+++ b/skills/supabase/SKILL.md
@@ -74,6 +74,15 @@ When working on any Supabase task that touches auth, RLS, views, storage, or use
 
 For any security concern not covered above, fetch the Supabase product security index: `https://supabase.com/docs/guides/security/product-security.md`
 
+## Repository Access Rules
+
+**Repository instructions outrank the workflows in this skill.** Before choosing a CLI, MCP, or local-database workflow, read the project's own agent instructions and MCP config (`AGENTS.md`, `CLAUDE.md`, `.mcp.json`, contributing docs). They are authoritative for project identity, access mode, and who approves writes.
+
+- **Confirm the project before the first remote call.** When the repository names a project-bound MCP server, verify its project ref or URL through that server, then keep all remote work on it — its read-only server for inspection, its write server only after the approval that server requires.
+- **Do not fall back to a path the repository rules out.** That includes `execute_sql` iteration, `supabase login`, the generic `mcp.supabase.com` OAuth flow, a local Supabase stack (Docker), `supabase db pull`, and `supabase db diff` when the repository forbids them or reserves them for local or CI use.
+- **Verify the objects you changed.** Run a full schema-drift audit only when the task or a release gate requires it.
+- **Stop at the access boundary.** If the authorized path fails, diagnose briefly, then report the boundary instead of switching credentials or runtimes.
+
 ## Supabase CLI
 
 Always discover commands via `--help` — never guess. The CLI structure changes between versions.
@@ -96,6 +105,8 @@ supabase <group> <command> --help  # Flags for a specific command
 
 For setup instructions, server URL, and configuration, see the [MCP setup guide](https://supabase.com/docs/guides/getting-started/mcp).
 
+If the repository already defines a project-bound MCP server, troubleshoot that server's configuration. Do not add a generic `mcp.supabase.com` entry beside it.
+
 **Troubleshooting connection issues** — follow these steps in order:
 
 1. **Check if the server is reachable:**
@@ -117,6 +128,8 @@ Before implementing any Supabase feature, find the relevant documentation. Use t
 3. **Web search** for Supabase-specific topics when you don't know which page to look at.
 
 ## Making and Committing Schema Changes
+
+Use the workflows below only when repository-specific instructions do not define a different authorized path, and distinguish local iteration from remote changes before running anything.
 
 First decide which schema workflow the project uses.
 


### PR DESCRIPTION
Closes #515

## What kind of change does this PR introduce?

Bug fix to the Supabase agent skill guidance.

## What is the current behavior?

In repositories that already define a project-bound Supabase access contract, the generic CLI, MCP troubleshooting, and schema-change guidance can steer an agent onto a different path than the repository authorizes.

For the case reported in #515, that can mean bypassing a read-only / approval-gated MCP split by falling back to `execute_sql`, `supabase login`, the generic `mcp.supabase.com` OAuth flow, a local Docker stack, `supabase db pull`, or `supabase db diff` even when the repository explicitly forbids or reserves those paths for local or CI use.

## What is the new behavior?

- Read repository/project instructions before selecting a CLI, MCP, or local-database workflow, and treat them as authoritative for project identity, access mode, and write approval.
- When a repository defines a project-bound MCP, verify the project through that server and preserve its read-only / approval-gated write boundary.
- Do not silently fall back to `execute_sql`, generic CLI/OAuth, local Supabase/Docker, `db pull`, or `db diff` when repository instructions rule those paths out.
- Prefer targeted verification of changed objects; run broad schema-drift checks only when the task or a release gate requires them.
- Qualify the generic MCP troubleshooting and schema-change sections so they do not override a repository-defined authorized path.

Local validation on the revised content: `pnpm test` — 7/7 passed (Node 24.14.1). Upstream Skills CI is currently approval-gated for this contributor, so this does not claim a green upstream CI run.

## Additional context

This is intentionally narrower than a general connection-fallback policy: it applies when the repository has already defined the authorized Supabase path.

Related open work on the same skill includes #425 (local runtime assumptions), #416 (hosted project identity preflight), #395 (general hosted connection fallbacks), and #117 (MCP project-listing gaps). Those are complementary or broader in scope; this PR establishes precedence for an explicit repository-specific access contract and may need coordination/rebase if any of them land first.

No `metadata.version` bump: Release Please owns skill version changes.